### PR TITLE
Add precisions about permissions and ownership

### DIFF
--- a/IRENE_guide.md
+++ b/IRENE_guide.md
@@ -4,6 +4,19 @@ Since we are now many adepts of th-top, sometimes we have to wait in the virtual
 
 *Access to IRENE: you need to complete a form and ask Cristiano and Loïc Noël, our IT responsible, to sign it.*
 
+### Storage systems on IRENE, quota, groups and ownership
+
+There are different accessible data spaces on IRENE, each coming with its own quota and specific rules. For details about this data spaces [see the doc](http://www-hpc.cea.fr/docs/userdoc-tgcc-public.pdf). 
+
+1) Home directory:
+
+- When you connect to IRENE you end up by default on your "home" directory. The exact path to this directory is stored in the variables HOME or CCFRHOME. The quota on this directory is small (5GB per user), but unlike other directories "home" is saved and not purged, so it must be used to store important files such as source code.
+
+2) Work directory
+
+- When working on IRENE it is preferable to use the "work" folder, which can be accessed by `cd $CCCWORKDIR` or `cd $CCFRWORK`. The quota policy on "work" is of 5 TB and 500 000 files/user. This file system is not purged but it is also not saved, so remember to make regular backups. 
+- For a file (or a directory) to be correctly taken into account for the quotas on "work", it must be owned by the project group (gen12462 in our case) and be granted the group rights. To check the ownership and permissions of files in a given directory use the command `ls -l`. To change the group of a file: `chown :<your_group> <your_directory_or_file>` (you can add the `-R`option to do this recursively on a given directory content). To grant group permission to a file use: `chmod g+s <your_directory_or_file>` (more details about this special permissions can be found [here](https://learning.lpi.org/en/learning-materials/010-160/5/5.3/5.3_01/)). Especially if you transfer files with rsync, you might need to add the following options to your rsync command: `--chown=:<your_group>`and  `--chmod=g+s`(or `--chmod=Dg+s` if you transfer a directory).
+
 ### Package installation
 
 IRENE does not have internet access, so you will not be able to add packages to julia in the usual way. 
@@ -17,7 +30,7 @@ To do so, follow these steps:
 5) Download julia-1.5: `wget https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.4-linux-x86_64.tar.gz`
 6) Decompress: `tar zxvf julia-1.5.4-linux-x86_64.tar.gz`
 7) Launch julia with `julia-1.5.4/bin/julia`, add packages you want and run `]precompile` to precompile everything
-8) Exit julia, and transfer your .julia directory to IRENE with `rsync -rvazh .julia/ username@irene-amd-fr.ccc.cea.fr:/ccc/cont003/home/unipdide/username/.julia/` (check that there is a .julia folder in IRENE). As an alternative, one may instead issue `rsync -rvazh username@th-top.mpq.univ-paris-diderot.fr:.julia/ .julia/` from the home directory on IRENE.
+8) Exit julia, and transfer your .julia directory to IRENE. If your Julia installation is too heavy you adapt the following commands to transfer the different files on you "work" directory. Otherwise you can install Julia directly on your "home" directory with `rsync -rvazh .julia/ username@irene-amd-fr.ccc.cea.fr:/ccc/cont003/home/unipdide/username/.julia/` (check that there is a .julia folder in IRENE). As an alternative, one may instead issue `rsync -rvazh username@th-top.mpq.univ-paris-diderot.fr:.julia/ .julia/` from the home directory on IRENE.
 9) Transfer the `julia-1.5.4` directory to IRENE, compress it with `tar` if too slow.
 10) Connect to Irene
 11) launch julia with `julia-1.5.4/bin/julia`, and precompile everything `]precompile`


### PR DESCRIPTION
To avoid quota errors, specify permission and ownership options to add to files that are transfered to or created on Irene. In fact for any file and directory to be taken into account on the right quota it must both be owned by the group corresponding to the project (gen12462 in our case, instead of the unipdide which is for university Paris Diderot) and the permission must be set so that the file/directory inherits from the group priviliege ("s" option in chmod, corresponding to set the group id bit, or gidbit).